### PR TITLE
Remove vsync and set 60fps by default

### DIFF
--- a/src/ui/compositor.rs
+++ b/src/ui/compositor.rs
@@ -48,7 +48,6 @@ impl Compositor {
 
         let canvas = main_window.into_canvas()
             .accelerated()
-            .present_vsync()
             .build()
             .unwrap();
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -5,5 +5,5 @@ pub mod compositor;
 pub mod controller;
 pub mod input;
 
-pub const RENDER_FPS: u64 = 30;
+pub const RENDER_FPS: u64 = 60;
 


### PR DESCRIPTION
Was having issues where the emulator would grind to a halt if rendering at 60fps. Turns out we must have been blocking on vsync a lot.

Turning vsync off fixes it completely.