### PR TITLE
Implement MMC3 mapper

### DIFF
--- a/src/emulator/components/latch.rs
+++ b/src/emulator/components/latch.rs
@@ -23,4 +23,8 @@ impl Latch {
     pub fn get(&self) -> State {
         self.state
     }
+
+    pub fn reset(&mut self) {
+        self.state = State::OFF;
+    }
 }

--- a/src/emulator/cpu/mod.rs
+++ b/src/emulator/cpu/mod.rs
@@ -102,10 +102,8 @@ impl clock::Ticker for CPU {
     #[inline]
     fn tick(&mut self) -> u32 {
         return if self.should_non_maskable_interrupt() {
-            self.nmi_flip_flop = false;
             self.non_maskable_interrupt()
         } else if self.should_interrupt() {
-            self.irq_flip_flop = false;
             self.interrupt()
         } else {
             self.execute_next_instruction()
@@ -206,12 +204,16 @@ impl CPU {
         8
     }
 
-    fn should_interrupt(&self) -> bool {
-        self.irq_flip_flop && !self.p.is_set(flags::Flag::I)
+    fn should_interrupt(&mut self) -> bool {
+        let should = self.irq_flip_flop && !self.p.is_set(flags::Flag::I);
+        self.irq_flip_flop = false;
+        should
     }
 
-    fn should_non_maskable_interrupt(&self) -> bool {
-        self.nmi_flip_flop
+    fn should_non_maskable_interrupt(&mut self) -> bool {
+        let should = self.nmi_flip_flop;
+        self.nmi_flip_flop = false;
+        should
     }
 
     fn decode_instruction(opcode: u8) -> (instructions::Operation, addressing::AddressingMode, u32) {

--- a/src/emulator/mappers/mmc3.rs
+++ b/src/emulator/mappers/mmc3.rs
@@ -55,7 +55,7 @@ impl MMC3 {
 
     fn clock_irq(&mut self) {
         if self.irq_counter == 0 || self.irq_reload_flag {
-            self.irq_flag = self.irq_enabled;
+            self.irq_flag = self.irq_enabled && self.irq_counter == 0;
             self.irq_counter = self.irq_counter_reload;
             self.irq_reload_flag = false;
         } else {
@@ -121,7 +121,7 @@ impl Mapper for MMC3 {
         // These can be broken into two independent functional units:
         //   - memory mapping ($8000, $8001, $A000, $A001)
         //   - scanline counting ($C000, $C001, $E000, $E001).
-        println!("${:X} = 0x{:X}", address, byte);
+        //println!("${:X} = 0x{:X}", address, byte);
         match address & 0xE000 {
             0x8000 => {
                 if address & 0x1 == 0 {

--- a/src/emulator/mappers/mmc3.rs
+++ b/src/emulator/mappers/mmc3.rs
@@ -182,8 +182,6 @@ impl Mapper for MMC3 {
     }
 
     fn irq_triggered(&mut self) -> bool {
-        let flag = self.irq_flag;
-        self.irq_flag = false;
-        flag
+        self.irq_flag
     }
 }

--- a/src/emulator/mappers/mmc3.rs
+++ b/src/emulator/mappers/mmc3.rs
@@ -148,9 +148,15 @@ impl Mapper for MMC3 {
                 }
             },
             0xA000 => {
-                self.mirror_mode = match byte & 0x1 == 0 {
-                    true => MirrorMode::Vertical,
-                    false => MirrorMode::Horizontal,
+                if address & 0x1 == 0 {
+                    // 0xA000, even => mirror mode.
+                    self.mirror_mode = match byte & 0x1 == 0 {
+                        true => MirrorMode::Vertical,
+                        false => MirrorMode::Horizontal,
+                    };
+                } else {
+                    // 0xA000, odd => PRG RAM protect
+                    // Unimplemented for compatibility with MMC6.
                 }
             },
             0xC000 => {

--- a/src/emulator/mappers/mmc3.rs
+++ b/src/emulator/mappers/mmc3.rs
@@ -1,0 +1,185 @@
+use emulator::memory::Mapper;
+use emulator::ppu::MirrorMode;
+
+// 1x 8kb PRG RAM - right now we have this sram outside the mappers, so ignored here.
+// 4x 8kb switchable PRG ROM
+// 2x 2kb switchable CHR ROM (we will treat this as 4x 1kb)
+// 4x 1kb switchable CHR ROM
+// Capable of generating IRQs.
+pub struct MMC3 {
+    prg_rom: Vec<u8>,
+    chr_rom: Vec<u8>,
+
+    // 8 registers for banks R0-R7, plus 2 slots which always point to the 2nd last and last PRG
+    // banks.
+    bank_registers: [usize; 10],
+    bank_select: usize,
+    prg_inversion: bool,
+    chr_inversion: bool,
+
+    irq_flag: bool,
+    irq_counter: u8,
+    irq_reload_flag: bool,
+    irq_counter_reload: u8,
+    irq_enabled: bool,
+
+    ppu_a12: bool,
+    ppu_a12_low_counter: u8,
+
+    mirror_mode: MirrorMode,
+}
+
+impl MMC3 {
+    pub fn new(prg_rom: Vec<u8>, chr_rom: Vec<u8>) -> MMC3 {
+        let mut m = MMC3 {
+            prg_rom,
+            chr_rom,
+            bank_registers: [0; 10],
+            bank_select: 0,
+            prg_inversion: false,
+            chr_inversion: false,
+            irq_flag: false,
+            irq_counter: 0,
+            irq_reload_flag: false,
+            irq_counter_reload: 0,
+            irq_enabled: false,
+            ppu_a12: false,
+            ppu_a12_low_counter: 0,
+            mirror_mode: MirrorMode::Horizontal,
+        };
+        let num_banks = m.prg_rom.len() / 0x2000;
+        m.bank_registers[8] = ((num_banks - 2) * 0x2000) as usize;
+        m.bank_registers[9] = ((num_banks - 1) * 0x2000) as usize;
+        m
+    }
+
+    fn clock_irq(&mut self) {
+        if self.irq_counter == 0 || self.irq_reload_flag {
+            self.irq_flag = self.irq_enabled;
+            self.irq_counter = self.irq_counter_reload;
+            self.irq_reload_flag = false;
+        } else {
+            self.irq_counter = self.irq_counter.saturating_sub(1);
+        }
+    }
+}
+
+impl Mapper for MMC3 {
+    fn read_chr(&mut self, address: u16) -> u8 {
+        let (bank_ix, bank_size) = match address {
+            // CHR banks.
+            0x0000 ... 0x03FF => if self.chr_inversion { (2, 0x400) } else { (0, 0x800) },
+            0x0400 ... 0x07FF => if self.chr_inversion { (3, 0x400) } else { (0, 0x800) },
+            0x0800 ... 0x0BFF => if self.chr_inversion { (4, 0x400) } else { (1, 0x800) },
+            0x0C00 ... 0x0FFF => if self.chr_inversion { (5, 0x400) } else { (1, 0x800) },
+            0x1000 ... 0x13FF => if self.chr_inversion { (0, 0x800) } else { (2, 0x400) },
+            0x1400 ... 0x17FF => if self.chr_inversion { (0, 0x800) } else { (3, 0x400) },
+            0x1800 ... 0x1BFF => if self.chr_inversion { (1, 0x800) } else { (4, 0x400) },
+            0x1C00 ... 0x1FFF => if self.chr_inversion { (1, 0x800) } else { (5, 0x400) },
+            _ => panic!("Unexpected address: ${:X}", address),
+        };
+
+        let base = self.bank_registers[bank_ix];
+        let offset = (address % bank_size) as usize;
+
+        // Update A12 and clock IRQ.
+        let a12 = address & 0x1000 == 0x1000;
+        if a12 && !self.ppu_a12 && self.ppu_a12_low_counter > 12 {
+            self.clock_irq();
+        } else if !a12 && !self.ppu_a12 {
+            self.ppu_a12_low_counter += 1;
+        } else if a12 {
+            self.ppu_a12_low_counter = 0;
+        }
+        self.ppu_a12 = a12;
+        self.chr_rom[base + offset]
+    }
+
+    fn write_chr(&mut self, _address: u16, _byte: u8) {
+        // CHR ROM not writeable.
+    }
+
+    fn read_prg(&mut self, address: u16) -> u8 {
+        let (bank_ix, bank_size) = match address {
+            // PRG banks.
+            0x8000 ... 0x9FFF => if self.prg_inversion { (8, 0x2000) } else { (6, 0x2000) },
+            0xA000 ... 0xBFFF => if self.prg_inversion { (7, 0x2000) } else { (7, 0x2000) },
+            0xC000 ... 0xDFFF => if self.prg_inversion { (6, 0x2000) } else { (8, 0x2000) },
+            0xE000 ... 0xFFFF => if self.prg_inversion { (9, 0x2000) } else { (9, 0x2000) },
+            _ => panic!("Unexpected address: ${:X}", address),
+        };
+
+        let base = self.bank_registers[bank_ix];
+        let offset = (address % bank_size) as usize;
+        self.prg_rom[base + offset]
+    }
+
+    fn write_prg(&mut self, address: u16, byte: u8) {
+        // The MMC3 has 4 pairs of registers at $8000-$9FFF, $A000-$BFFF, $C000-$DFFF, and $E000-$FFFF
+        //   - even addresses ($8000, $8002, etc.) select the low register 
+        //   - odd addresses ($8001, $8003, etc.) select the high register in each pair.
+        // These can be broken into two independent functional units:
+        //   - memory mapping ($8000, $8001, $A000, $A001)
+        //   - scanline counting ($C000, $C001, $E000, $E001).
+        println!("${:X} = 0x{:X}", address, byte);
+        match address & 0xE000 {
+            0x8000 => {
+                if address & 0x1 == 0 {
+                    // 0x8000, even => Bank select
+                    self.bank_select = (byte & 0x0F) as usize;
+                    self.prg_inversion = byte & 0x40 == 0x40;
+                    self.chr_inversion = byte & 0x80 == 0x80;
+                } else {
+                    // 0x8000, odd => Bank data
+                    // Handle PRG and CHR separately.
+                    if self.bank_select >= 6 {
+                        // PRG, 8kb banks, ignores top 2 bits.
+                        self.bank_registers[self.bank_select] = ((byte & 0x7F) as usize) << 13;
+                    } else if self.bank_select <= 1 {
+                        // 2kb CHR banks can only select even banks.
+                        self.bank_registers[self.bank_select] = ((byte & 0xFE) as usize) << 10;
+                    } else {
+                        self.bank_registers[self.bank_select] = (byte as usize) << 10;
+                    }
+                }
+            },
+            0xA000 => {
+                self.mirror_mode = match byte & 0x1 == 0 {
+                    true => MirrorMode::Vertical,
+                    false => MirrorMode::Horizontal,
+                }
+            },
+            0xC000 => {
+                if address & 0x1 == 0 {
+                    // 0xC000, even => IRQ Latch
+                    self.irq_counter_reload = byte;
+                } else {
+                    // 0xC000, odd => IRQ Reload
+                    self.irq_reload_flag = true;
+                }
+            },
+            0xE000 => {
+                if address & 0x1 == 0 {
+                    // 0xE000, even => IRQ disable
+                    self.irq_enabled = false;
+                    self.irq_flag = false;
+                } else {
+                    // 0xE000, odd => IRQ enable
+                    self.irq_enabled = true;
+                }
+            },
+
+            _ => panic!("Unexpected address: ${:X}", address),
+        }
+    }
+
+    fn mirror_mode(&self) -> MirrorMode {
+        self.mirror_mode
+    }
+
+    fn irq_triggered(&mut self) -> bool {
+        let flag = self.irq_flag;
+        self.irq_flag = false;
+        flag
+    }
+}

--- a/src/emulator/mappers/mmc3.rs
+++ b/src/emulator/mappers/mmc3.rs
@@ -87,7 +87,7 @@ impl Mapper for MMC3 {
 
         // Update A12 and clock IRQ.
         let a12 = address & 0x1000 == 0x1000;
-        if a12 && !self.ppu_a12 && self.ppu_a12_low_counter > 6 {
+        if a12 && !self.ppu_a12 && self.ppu_a12_low_counter > 12 {
             self.clock_irq();
         } else if !a12 && !self.ppu_a12 {
             self.ppu_a12_low_counter += 1;
@@ -99,8 +99,8 @@ impl Mapper for MMC3 {
         self.chr_rom[base + offset]
     }
 
-    fn write_chr(&mut self, _address: u16, _byte: u8) {
-        // CHR ROM not writeable.
+    fn write_chr(&mut self, address: u16, byte: u8) {
+        self.chr_rom[address as usize] = byte;
     }
 
     fn read_prg(&mut self, address: u16) -> u8 {

--- a/src/emulator/mappers/mod.rs
+++ b/src/emulator/mappers/mod.rs
@@ -1,8 +1,12 @@
 // In iNES mapper number order.
 
-// #1 NROM
+// #0 NROM
 mod nrom;
 pub use self::nrom::NROM;
+
+// #1 MMC1
+mod mmc1;
+pub use self::mmc1::MMC1;
 
 // #2 UxROM
 mod uxrom;
@@ -12,9 +16,9 @@ pub use self::uxrom::UXROM;
 mod cnrom;
 pub use self::cnrom::CNROM;
 
-// #4 MMC1
-mod mmc1;
-pub use self::mmc1::MMC1;
+// #4 MMC3
+mod mmc3;
+pub use self::mmc3::MMC3;
 
 // #7 AxROM
 mod axrom;

--- a/src/emulator/memory.rs
+++ b/src/emulator/memory.rs
@@ -179,6 +179,9 @@ pub trait Mapper {
     fn read_prg(&mut self, address: u16) -> u8;
     fn write_prg(&mut self, address: u16, byte: u8);
     fn mirror_mode(&self) -> MirrorMode;
+    fn irq_triggered(&mut self) -> bool {
+        false
+    }
 }
 
 pub type MapperRef = Rc<RefCell<dyn Mapper>>;

--- a/src/emulator/mod.rs
+++ b/src/emulator/mod.rs
@@ -144,9 +144,6 @@ impl NES {
         }
 
         if self.mapper.borrow_mut().irq_triggered() {
-            let scanline = self.ppu.borrow().scanline;
-            let cycle = self.ppu.borrow().cycle;
-            println!("IRQ at scanline {}, cycle {}", scanline, cycle);
             self.cpu.borrow_mut().trigger_irq();
         }
 

--- a/src/emulator/mod.rs
+++ b/src/emulator/mod.rs
@@ -37,6 +37,7 @@ pub struct NES {
     pub cpu: Rc<RefCell<cpu::CPU>>,
     pub ppu: Rc<RefCell<ppu::PPU>>,
     pub apu: Rc<RefCell<apu::APU>>,
+    pub mapper: Rc<RefCell<memory::Mapper>>,
     nmi_pin: bool,
 }
 
@@ -121,6 +122,7 @@ impl NES {
             cpu,
             ppu,
             apu,
+            mapper,
             nmi_pin: false,
         }
     }
@@ -141,6 +143,13 @@ impl NES {
             self.cpu.borrow_mut().trigger_irq();
         }
 
+        if self.mapper.borrow_mut().irq_triggered() {
+            let scanline = self.ppu.borrow().scanline;
+            let cycle = self.ppu.borrow().cycle;
+            println!("IRQ at scanline {}, cycle {}", scanline, cycle);
+            self.cpu.borrow_mut().trigger_irq();
+        }
+
         cycles
     }
 
@@ -154,6 +163,7 @@ impl NES {
             1 => Rc::new(RefCell::new(mappers::MMC1::new(prg_rom, chr_rom))),
             2 => Rc::new(RefCell::new(mappers::UXROM::new(prg_rom, chr_rom, mirror_mode))),
             3 => Rc::new(RefCell::new(mappers::CNROM::new(prg_rom, chr_rom, mirror_mode))),
+            4 => Rc::new(RefCell::new(mappers::MMC3::new(prg_rom, chr_rom))),
             7 => Rc::new(RefCell::new(mappers::AXROM::new(prg_rom, chr_rom))),
             _ => panic!("Unknown mapper: {}", rom.mapper_number()),
         }

--- a/src/emulator/ppu/mod.rs
+++ b/src/emulator/ppu/mod.rs
@@ -53,7 +53,7 @@ impl <V : VideoOut> VideoOut for Rc<RefCell<V>> {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum MirrorMode {
     SingleLower,
     SingleUpper,

--- a/src/emulator/ppu/mod.rs
+++ b/src/emulator/ppu/mod.rs
@@ -154,10 +154,10 @@ pub struct PPU {
 
     // There are 262 scanlines in total. 0-239 are visible, 240-260 occur durng vblank, and 261 is
     // idle.
-    scanline: u16,
+    pub scanline: u16,
 
     // Each scanline takes 341 cycles to render.
-    cycle: u16,
+    pub cycle: u16,
 
     // Every odd frame is one cycle short.
     is_odd_frame: bool,

--- a/src/emulator/ppu/registers.rs
+++ b/src/emulator/ppu/registers.rs
@@ -64,9 +64,15 @@ impl Reader for PPU {
                 let addr = self.v;
                 let byte = self.memory.read(addr);
 
-                // Amount to increment by is determined by PPUCTRL.
-                let inc = self.ppuaddr_increment();
-                self.v = self.v.wrapping_add(inc);
+                if self.is_rendering() {
+                    // v is modified strangely if we're accessing it during rendering.
+                    self.increment_coarse_x();
+                    self.increment_y();
+                } else {
+                    // Amount to increment by is determined by PPUCTRL.
+                    let inc = self.ppuaddr_increment();
+                    self.v = self.v.wrapping_add(inc);
+                }
 
                 if addr < 0x3F00 {
                     // Reading from before palettes, buffer the read.
@@ -189,9 +195,15 @@ impl Writer for PPU {
                 // Write byte and increment VRAM address.
                 self.memory.write(self.v, byte);
 
-                // Amount to increment by is determined by PPUCTRL.
-                let inc = self.ppuaddr_increment();
-                self.v = self.v.wrapping_add(inc);
+                if self.is_rendering() {
+                    // v is modified strangely if we're accessing it during rendering.
+                    self.increment_coarse_x();
+                    self.increment_y();
+                } else {
+                    // Amount to increment by is determined by PPUCTRL.
+                    let inc = self.ppuaddr_increment();
+                    self.v = self.v.wrapping_add(inc);
+                }
             },
 
             _ => panic!("Unexpected PPU register address: {}", address),

--- a/src/emulator/ppu/registers.rs
+++ b/src/emulator/ppu/registers.rs
@@ -33,7 +33,9 @@ impl Reader for PPU {
                 let byte = self.ppustatus.as_byte() & 0b1110_0000;
 
                 // After reading PPUSTATUS, vblank flag is cleared.
+                // And ppuaddr latch is reset.
                 self.ppustatus.clear(flags::PPUSTATUS::V);
+                self.write_latch.reset();
                 Some(byte)
             },
 


### PR DESCRIPTION
Example: SMB3:
![smb3](https://user-images.githubusercontent.com/3620166/48674031-1166e800-eb83-11e8-8a3d-33eeb06060ee.gif)

In the process I also fixed another couple of non-mmc3 related bugs which make Battletoads much much better.

Crystalis also works almost flawlessly, just a few visual glitches.  I think probably because my IRQ timing is still not exactly correct, it's sometimes 1 scanline too late I think, but not sure why.